### PR TITLE
Reuse pinned candidates during `pdm install`

### DIFF
--- a/news/33.feature
+++ b/news/33.feature
@@ -1,0 +1,1 @@
+Pinned candidates in lock file are reused when relocking during `pdm install`.

--- a/pdm.lock
+++ b/pdm.lock
@@ -566,6 +566,5 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 ]
 
 [root]
-content_hash = "md5:8ec515deecaf048153dca8ca3e57572b"
+content_hash = "md5:b1e4f14a9b7fea899f6f57f7b3c081a1"
 meta_version = "0.0.1"
-

--- a/pdm/cli/commands.py
+++ b/pdm/cli/commands.py
@@ -103,10 +103,15 @@ def lock(project):
 )
 @pass_project
 def install(project, sections, dev, default, lock):
-    if lock and not (
-        project.lockfile_file.is_file() and project.is_lockfile_hash_match()
-    ):
-        actions.do_lock(project)
+    if lock:
+        if not project.lockfile_file.exists():
+            context.io.echo("Lock file does not exist, trying to generate one...")
+            actions.do_lock(project, strategy="all")
+        elif not project.is_lockfile_hash_match():
+            context.io.echo(
+                "Lock file hash doesn't match pyproject.toml, regenerating..."
+            )
+            actions.do_lock(project, strategy="reuse")
     actions.do_sync(project, sections, dev, default, False, False)
 
 

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -177,7 +177,7 @@ class Project:
             return {}
         section = section or "default"
         result = {}
-        for package in [dict(p) for p in self.lockfile["package"]]:
+        for package in [dict(p) for p in self.lockfile.get("package", [])]:
             if section != "__all__" and section not in package["sections"]:
                 continue
             version = package.get("version")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 from pdm.cli import actions, commands
+from pdm.models.requirements import parse_requirement
 
 
 @pytest.fixture()
@@ -109,3 +110,16 @@ def test_use_command(project, invoke):
     project.write_pyproject()
     result = invoke(["use", "2.7"], obj=project)
     assert result.exit_code == 1
+
+
+def test_install_with_lockfile(project, invoke, working_set, repository):
+    result = invoke(["lock"], obj=project)
+    assert result.exit_code == 0
+    result = invoke(["install"], obj=project)
+    assert "Lock file" not in result.output
+
+    project.add_dependencies({"pytz": parse_requirement("pytz")})
+    result = invoke(["install"], obj=project)
+    assert "Lock file hash doesn't match" in result.output
+    assert "pytz" in project.get_locked_candidates()
+    assert project.is_lockfile_hash_match()


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

Close #33 