### PR TITLE
Fix global project dependencies (wheels -> wheel)

### DIFF
--- a/news/182.bugfix
+++ b/news/182.bugfix
@@ -1,0 +1,1 @@
+Require `wheel` not `wheels` for global projects

--- a/pdm/project/core.py
+++ b/pdm/project/core.py
@@ -404,7 +404,7 @@ class Project:
 [tool.pdm.dependencies]
 pip = "*"
 setuptools = "*"
-wheels = "*"
+wheel = "*"
 
 [tool.pdm.dev-dependencies]
 """


### PR DESCRIPTION
`wheels` is among the minimum dependencies injected for global projects resulting in crashes.

This change corrects the typo to `wheel`.

Below is an example traceback of the error

```
======== Start resolving requirements ========
	pip
	setuptools
	wheels
	Adding requirement pip
	Adding requirement setuptools
	Adding requirement wheels
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/pdm/resolver/core.py", line 23, in _merge_into_criterion
    crit = self.state.criteria[name]
KeyError: 'wheels'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/resolvelib/resolvers.py", line 310, in resolve
    name, crit = self._merge_into_criterion(r, parent=None)
  File "/usr/local/lib/python3.9/site-packages/pdm/resolver/core.py", line 25, in _merge_into_criterion
    crit = Criterion.from_requirement(self._p, requirement, parent)
  File "/usr/local/lib/python3.9/site-packages/resolvelib/resolvers.py", line 83, in from_requirement
    raise RequirementsConflicted(criterion)
resolvelib.resolvers.RequirementsConflicted: Requirements conflict: <NamedRequirement wheels>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/pdm", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/pdm/core.py", line 71, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/pdm/core.py", line 106, in main
    raise err.with_traceback(traceback)
  File "/usr/local/lib/python3.9/site-packages/pdm/core.py", line 102, in main
    f(options.project, options)
  File "/usr/local/lib/python3.9/site-packages/pdm/cli/commands/install.py", line 33, in handle
    actions.do_lock(project, strategy="all")
  File "/usr/local/lib/python3.9/site-packages/pdm/cli/actions.py", line 61, in do_lock
    mapping, dependencies, summaries = resolve(
  File "/usr/local/lib/python3.9/site-packages/pdm/resolver/core.py", line 135, in resolve
    result = resolver.resolve(requirements)
  File "/usr/local/lib/python3.9/site-packages/resolvelib/resolvers.py", line 445, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/usr/local/lib/python3.9/site-packages/resolvelib/resolvers.py", line 312, in resolve
    raise ResolutionImpossible(e.criterion.information)
resolvelib.resolvers.ResolutionImpossible: [RequirementInformation(requirement=<NamedRequirement wheels>, parent=None)]
```

## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.
