### PR TITLE
VSCode Task Provider Documentation

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -153,3 +153,14 @@ Add following in the `settings.json`:
   "python.autoComplete.extraPaths": ["__pypackages__/<major.minor>/lib"]
 }
 ```
+
+#### Task Provider
+
+In addition, there is a [VSCode Task Provider extension][pdm task provider] available for download.
+
+This makes it possible for VSCode to automatically detect [pdm scripts][pdm scripts] so they
+can be run natively as [VSCode Tasks][vscode tasks].
+
+[vscode tasks]: https://code.visualstudio.com/docs/editor/tasks
+[pdm task provider]: https://marketplace.visualstudio.com/items?itemName=knowsuchagency.pdm-task-provider
+[pdm scripts]: https://pdm.fming.dev/project/#run-scripts-in-isolated-environment

--- a/news/280.doc.md
+++ b/news/280.doc.md
@@ -1,0 +1,1 @@
+added documentation on a [task provider for vscode](https://marketplace.visualstudio.com/items?itemName=knowsuchagency.pdm-task-provider)


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

I added a link to a [VSCode Task Provider extension](https://marketplace.visualstudio.com/items?itemName=knowsuchagency.pdm-task-provider) to the documentation for VSCode integration. 

My apologies, but I couldn't figure out how to properly add an entry in `/news` for `towncrier`, but would be happy to do so if given instructions on how.

Thanks!