### PR TITLE
Adding an example install failure and test case for fallback

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -319,6 +319,13 @@ def test_completion_command(invoke):
     assert "(completion)" in result.output
 
 
+def test_lock_install_failure_project(invoke, fixture_project, repository):
+    project = fixture_project("demo-install-failure")
+    result = invoke(["lock"], obj=project)
+    assert result.exit_code == 0
+    assert "fido2" in project.get_locked_candidates()
+
+
 def test_lock_legacy_project(invoke, fixture_project, repository):
     project = fixture_project("demo-legacy")
     result = invoke(["lock"], obj=project)

--- a/tests/fixtures/projects/demo-install-failure/demo.py
+++ b/tests/fixtures/projects/demo-install-failure/demo.py
@@ -1,0 +1,3 @@
+import os
+
+print(os.name)

--- a/tests/fixtures/projects/demo-install-failure/pyproject.toml
+++ b/tests/fixtures/projects/demo-install-failure/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+# PEP 621 project metadata
+# See https://www.python.org/dev/peps/pep-0621/
+authors = [
+    {name = "frostming", email = "mianghong@gmail.com"},
+]
+version = "0.1.0"
+requires-python = ">=3.5"
+license = {text = "MIT"}
+dependencies = ["fido2==0.9.1"]
+dev-dependencies = []
+description = ""
+name = "demo-package-install-failure"
+
+[project.urls]
+homepage = ""
+
+[build-system]
+requires = ["pdm-pep517"]
+build-backend = "pdm.pep517.api"


### PR DESCRIPTION
This isn't a fix, sorry! This is a test case to reproduce #299 - as reported earlier in #293

Check out this branch, then:

```
cd tests/fixtures/projects/demo-install-failure
pdm lock -v
```

And you'll see:

```
======== Start resolving requirements ========
	fido2==0.9.1
	Adding requirement fido2==0.9.1
	Adding requirement six(from fido2 0.9.1)
	Adding requirement cryptography>=1.5(from fido2 0.9.1)
	Adding requirement uhid-freebsd>=1.2.1; platform_system == "FreeBSD"(from fido2 0.9.1)
Resolving: fido2 0.9.1
	New pin: fido2 0.9.1
======== Ending round 0 ========
Preparing isolated env for PEP 517 build...
Requirement already satisfied: setuptools>=40.8.0 in /usr/local/lib/python3.9/site-packages (from -r /var/folders/tj/wz8q0jmx7_92n64zpvh4kh5h0000gn/T/pdm-build-reqs-uzpk5gz4.txt (line 1)) (53.0.0)
Requirement already satisfied: wheel in /usr/local/lib/python3.9/site-packages (from -r /var/folders/tj/wz8q0jmx7_92n64zpvh4kh5h0000gn/T/pdm-build-reqs-uzpk5gz4.txt (line 2)) (0.36.2)
running egg_info
writing uhid_freebsd.egg-info/PKG-INFO
writing dependency_links to uhid_freebsd.egg-info/dependency_links.txt
writing top-level names to uhid_freebsd.egg-info/top_level.txt
reading manifest file 'uhid_freebsd.egg-info/SOURCES.txt'
writing manifest file 'uhid_freebsd.egg-info/SOURCES.txt'
Requirement already satisfied: wheel in /usr/local/lib/python3.9/site-packages (from -r /var/folders/tj/wz8q0jmx7_92n64zpvh4kh5h0000gn/T/pdm-build-reqs-2cfj3cje.txt (line 1)) (0.36.2)
running bdist_wheel
running build
running build_ext
building 'uhid_freebsd' extension
creating build
creating build/temp.macosx-11-x86_64-3.9
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/sqlite/include -I/usr/local/opt/tcl-tk/include -I/usr/local/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c uhid_freebsd.cpp -o build/temp.macosx-11-x86_64-3.9/uhid_freebsd.o
uhid_freebsd.cpp:15:10: fatal error: 'dev/usb/usb_ioctl.h' file not found
#include <dev/usb/usb_ioctl.h>
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
error: command '/usr/bin/clang' failed with exit code 1
Failed to build package, try parsing project files.
Traceback (most recent call last):
  File "/usr/local/bin/pdm", line 8, in <module>
    sys.exit(main())
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/core.py", line 76, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/core.py", line 131, in main
    raise err.with_traceback(traceback)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/core.py", line 127, in main
    f(options.project, options)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/cli/commands/lock.py", line 12, in handle
    actions.do_lock(project)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/cli/actions.py", line 70, in do_lock
    mapping, dependencies, summaries = resolve(
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/resolver/core.py", line 152, in resolve
    result = resolver.resolve(requirements, max_rounds)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/resolvelib/resolvers.py", line 454, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/resolvelib/resolvers.py", line 348, in resolve
    failure_causes = self._attempt_to_pin_criterion(name, criterion)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/resolvelib/resolvers.py", line 208, in _attempt_to_pin_criterion
    criteria = self._get_criteria_to_update(candidate)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/resolvelib/resolvers.py", line 199, in _get_criteria_to_update
    for r in self._p.get_dependencies(candidate=candidate):
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/resolver/providers.py", line 77, in get_dependencies
    deps, requires_python, summary = self.repository.get_dependencies(candidate)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/models/repositories.py", line 64, in get_dependencies
    requirements, requires_python, summary = getter(candidate)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/models/repositories.py", line 30, in wrapper
    result = func(self, candidate)
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/models/repositories.py", line 141, in _get_dependencies_from_metadata
    deps = candidate.get_dependencies_from_metadata()
  File "/usr/local/Cellar/pdm/1.4.1/libexec/lib/python3.9/site-packages/pdm/models/candidates.py", line 214, in get_dependencies_from_metadata
    return filter_requirements_with_extras(metadata.run_requires, extras)
AttributeError: 'Namespace' object has no attribute 'run_requires'
```

... or at least I do. ;-)

You can also run `pdm run pytest tests/cli/test_cli.py -v` but it won't give you the above details.

Unfortunately, I don't have a fix for this, because I don't have time to figure out what's gone wrong. All I can do is share how to reproduce the error In a simple way. I hope it helps!