### PR TITLE
Typing/iostream

### DIFF
--- a/news/301.misc.md
+++ b/news/301.misc.md
@@ -1,0 +1,1 @@
+refactor `pdm.iostream` to improve 'typing' support

--- a/pdm/__init__.py
+++ b/pdm/__init__.py
@@ -1,6 +1,7 @@
 from pkgutil import extend_path
+from typing import Iterable
 
-__path__ = extend_path(__path__, __name__)
+__path__: Iterable[str] = extend_path(__path__, __name__)
 # Export for plugin use
 from pdm.cli.commands.base import BaseCommand
 from pdm.core import Core

--- a/pdm/__init__.py
+++ b/pdm/__init__.py
@@ -1,7 +1,6 @@
 from pkgutil import extend_path
-from typing import Iterable
 
-__path__: Iterable[str] = extend_path(__path__, __name__)
+__path__ = extend_path(__path__, __name__)
 # Export for plugin use
 from pdm.cli.commands.base import BaseCommand
 from pdm.core import Core

--- a/pdm/iostream.py
+++ b/pdm/iostream.py
@@ -64,6 +64,7 @@ class IOStream:
     DETAIL = 1
     DEBUG = 2
 
+    @staticmethod
     def _style(text: str, *args, **kwargs) -> str:
         if _SUPPORTS_ANSI:
             return click.style(text, *args, **kwargs)

--- a/pdm/iostream.py
+++ b/pdm/iostream.py
@@ -59,16 +59,16 @@ def _supports_ansi() -> bool:
 _SUPPORTS_ANSI = _supports_ansi()
 
 
+def _style(text: str, *args, **kwargs) -> str:
+    if _SUPPORTS_ANSI:
+        return click.style(text, *args, **kwargs)
+    return text
+
+
 class IOStream:
     NORMAL = 0
     DETAIL = 1
     DEBUG = 2
-
-    @staticmethod
-    def _style(text: str, *args, **kwargs) -> str:
-        if _SUPPORTS_ANSI:
-            return click.style(text, *args, **kwargs)
-        return text
 
     green = functools.partial(_style, fg="green")
     cyan = functools.partial(_style, fg="cyan")

--- a/pdm/iostream.py
+++ b/pdm/iostream.py
@@ -56,25 +56,38 @@ def _supports_ansi() -> bool:
         return False
 
 
-_SUPPORTS_ANSI = _supports_ansi()
-
-
-def _style(text: str, *args, **kwargs) -> str:
-    if _SUPPORTS_ANSI:
-        return click.style(text, *args, **kwargs)
-    return text
-
-
 class IOStream:
     NORMAL = 0
     DETAIL = 1
     DEBUG = 2
 
-    green = functools.partial(_style, fg="green")
-    cyan = functools.partial(_style, fg="cyan")
-    yellow = functools.partial(_style, fg="yellow")
-    red = functools.partial(_style, fg="red")
-    bold = functools.partial(_style, bold=True)
+    supports_ansi = _supports_ansi()
+
+    @classmethod
+    def _style(cls, text: str, *args, **kwargs) -> str:
+        if cls.supports_ansi:
+            return click.style(text, *args, **kwargs)
+        return text
+
+    @classmethod
+    def green(cls, text: str, *args, **kwargs) -> str:
+        return cls._style(text, *args, **kwargs, fg="green")
+
+    @classmethod
+    def cyan(cls, text: str, *args, **kwargs) -> str:
+        return cls._style(text, *args, **kwargs, fg="cyan")
+
+    @classmethod
+    def yellow(cls, text: str, *args, **kwargs) -> str:
+        return cls._style(text, *args, **kwargs, fg="yellow")
+
+    @classmethod
+    def red(cls, text: str, *args, **kwargs) -> str:
+        return cls._style(text, *args, **kwargs, fg="red")
+
+    @classmethod
+    def bold(cls, text: str, *args, **kwargs) -> str:
+        return cls._style(text, *args, **kwargs, bold=True)
 
     def __init__(self, verbosity: int = NORMAL, disable_colors: bool = False) -> None:
         self.verbosity = verbosity
@@ -149,7 +162,7 @@ class IOStream:
                 pass
 
     def open_spinner(self, title: str, spinner: str = "dots") -> ContextManager:
-        if self.verbosity >= self.DETAIL or not _SUPPORTS_ANSI:
+        if self.verbosity >= self.DETAIL or not self.supports_ansi:
             return DummySpinner()
         else:
             return halo.Halo(title, spinner=spinner, indent=self._indent)

--- a/pdm/iostream.py
+++ b/pdm/iostream.py
@@ -7,7 +7,7 @@ import re
 import sys
 from itertools import zip_longest
 from tempfile import mktemp
-from typing import ContextManager, Generator, List, Optional
+from typing import ContextManager, List, Optional
 
 import click
 
@@ -147,17 +147,11 @@ class IOStream:
             except OSError:
                 pass
 
-    @contextlib.contextmanager
-    def open_spinner(
-        self, title: str, spinner: str = "dots"
-    ) -> Generator[ContextManager, None, None]:
-        bar: ContextManager
+    def open_spinner(self, title: str, spinner: str = "dots") -> ContextManager:
         if self.verbosity >= self.DETAIL or not self.supports_ansi:
-            bar = DummySpinner()
+            return DummySpinner()
         else:
-            bar = halo.Halo(title, spinner=spinner, indent=self._indent)
-        with bar as bar:
-            yield bar
+            return halo.Halo(title, spinner=spinner, indent=self._indent)
 
 
 stream = IOStream()

--- a/pdm/iostream.py
+++ b/pdm/iostream.py
@@ -66,7 +66,7 @@ class IOStream:
             return click.style(text, *args, **kwargs)
         return text
 
-    def __init__(self, verbosity: int = NORMAL, disable_colors: bool = False) -> None:
+    def __init__(self, verbosity: int = NORMAL) -> None:
         self.verbosity = verbosity
         self._indent = ""
         logger = logging.getLogger(__name__)

--- a/pdm/iostream.py
+++ b/pdm/iostream.py
@@ -61,33 +61,10 @@ class IOStream:
     DETAIL = 1
     DEBUG = 2
 
-    supports_ansi = _supports_ansi()
-
-    @classmethod
-    def _style(cls, text: str, *args, **kwargs) -> str:
-        if cls.supports_ansi:
+    def _style(self, text: str, *args, **kwargs) -> str:
+        if self.supports_ansi:
             return click.style(text, *args, **kwargs)
         return text
-
-    @classmethod
-    def green(cls, text: str, *args, **kwargs) -> str:
-        return cls._style(text, *args, **kwargs, fg="green")
-
-    @classmethod
-    def cyan(cls, text: str, *args, **kwargs) -> str:
-        return cls._style(text, *args, **kwargs, fg="cyan")
-
-    @classmethod
-    def yellow(cls, text: str, *args, **kwargs) -> str:
-        return cls._style(text, *args, **kwargs, fg="yellow")
-
-    @classmethod
-    def red(cls, text: str, *args, **kwargs) -> str:
-        return cls._style(text, *args, **kwargs, fg="red")
-
-    @classmethod
-    def bold(cls, text: str, *args, **kwargs) -> str:
-        return cls._style(text, *args, **kwargs, bold=True)
 
     def __init__(self, verbosity: int = NORMAL, disable_colors: bool = False) -> None:
         self.verbosity = verbosity
@@ -96,6 +73,13 @@ class IOStream:
         logger.setLevel(logging.DEBUG)
         logger.addHandler(logging.NullHandler())
         self.logger = logger
+        self.supports_ansi = _supports_ansi()
+
+        self.green = functools.partial(self._style, fg="green")
+        self.cyan = functools.partial(self._style, fg="cyan")
+        self.yellow = functools.partial(self._style, fg="yellow")
+        self.red = functools.partial(self._style, fg="red")
+        self.bold = functools.partial(self._style, bold=True)
 
     def set_verbosity(self, verbosity: int) -> None:
         self.verbosity = verbosity

--- a/pdm/utils.py
+++ b/pdm/utils.py
@@ -198,7 +198,7 @@ def convert_hashes(hashes: Dict[str, str]) -> Dict[str, List[str]]:
     The option format uses a str-list mapping. Keys are hash algorithms, and
     the list contains all values of that algorithm.
     """
-    result = {}
+    result: Dict[str, List[str]] = {}
     for hash_value in hashes.values():
         try:
             name, hash_value = hash_value.split(":")


### PR DESCRIPTION
- remove `setattr`
- add type annotations to spinner context manager

these changes alone knock out around 100 mypy errors.

note, this pull request is stacked on top of #298, so that should be merged first, and this pull request can be rebased