### PR TITLE
Bugfix: Get dependencies error when the setup.py has no install_requires key

### DIFF
--- a/news/299.bugfix.md
+++ b/news/299.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that get_dependencies() returns error when the `setup.py` has no `intall_requires` key.

--- a/pdm/models/candidates.py
+++ b/pdm/models/candidates.py
@@ -205,8 +205,8 @@ class Candidate:
             if not metadata:
                 return []
             return get_requirements_from_dist(self.ireq.get_dist(), extras)
-        elif getattr(metadata, "install_requires", None):
-            requires = metadata.install_requires
+        elif hasattr(metadata, "install_requires"):
+            requires = metadata.install_requires or []
             for extra in extras:
                 requires.extend(metadata.extras_require.get(extra, []))
             return sorted(set(requires))

--- a/pdm/models/candidates.py
+++ b/pdm/models/candidates.py
@@ -207,8 +207,14 @@ class Candidate:
             return get_requirements_from_dist(self.ireq.get_dist(), extras)
         elif hasattr(metadata, "install_requires"):
             requires = metadata.install_requires or []
+            extras_not_found = set()
             for extra in extras:
-                requires.extend(metadata.extras_require.get(extra, []))
+                try:
+                    requires.extend((metadata.extras_require or {})[extra])
+                except KeyError:
+                    extras_not_found.add(extra)
+            if extras_not_found:
+                warnings.warn(ExtrasError(sorted(extras_not_found)))
             return sorted(set(requires))
         else:
             return filter_requirements_with_extras(metadata.run_requires, extras)

--- a/pdm/models/requirements.py
+++ b/pdm/models/requirements.py
@@ -435,7 +435,7 @@ def filter_requirements_with_extras(
 
     extras_not_found = [e for e in extras if e not in extras_in_meta]
     if extras_not_found:
-        warnings.warn(ExtrasError(extras_not_found), stacklevel=2)
+        warnings.warn(ExtrasError(extras_not_found))
 
     return result
 

--- a/tests/fixtures/projects/demo-failure-no-dep/demo.py
+++ b/tests/fixtures/projects/demo-failure-no-dep/demo.py
@@ -1,0 +1,5 @@
+import os
+
+import chardet
+
+print(os.name)

--- a/tests/fixtures/projects/demo-failure-no-dep/setup.py
+++ b/tests/fixtures/projects/demo-failure-no-dep/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+if True:
+    raise RuntimeError("This mimics the build error on unmatched platform")
+
+setup(
+    name="demo",
+    version="0.0.1",
+    description="test demo",
+    py_modules=["demo"],
+    python_requires=">=3.3",
+)

--- a/tests/models/test_candidates.py
+++ b/tests/models/test_candidates.py
@@ -133,3 +133,11 @@ def test_parse_project_file_on_build_error(project):
     ]
     assert candidate.name == "demo"
     assert candidate.version == "0.0.1"
+
+
+def test_parse_project_file_on_build_error_no_dep(project):
+    req = parse_requirement(f"{(FIXTURES / 'projects/demo-failure-no-dep').as_posix()}")
+    candidate = Candidate(req, project.environment)
+    assert candidate.get_dependencies_from_metadata() == []
+    assert candidate.name == "demo"
+    assert candidate.version == "0.0.1"


### PR DESCRIPTION
## Pull Request Check List

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.
Fix #299

/cc @LouisStAmour 