### PR TITLE
Add configuration to make pylance work

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -154,7 +154,8 @@ Add following in the `settings.json`:
 ```json
 {
   ...
-  "python.autoComplete.extraPaths": ["__pypackages__/<major.minor>/lib"]
+  "python.autoComplete.extraPaths": ["__pypackages__/<major.minor>/lib"],
+  "python.analysis.extraPaths": ["__pypackages__/<major.minor>/lib"]
 }
 ```
 


### PR DESCRIPTION
VSCode Pylance needs to be configured to correctly search for dependencies.