### PR TITLE
Allow `cmd` fields in `tool.pdm.scripts` section to contain arrays in addition to strings

### DIFF
--- a/docs/docs/project.md
+++ b/docs/docs/project.md
@@ -239,6 +239,19 @@ Plain text scripts are regarded as normal command, or you can explicitly specify
 start_server = {cmd = "flask run -p 54321"}
 ```
 
+In some cases, such as when wanting to add comments between parameters, it might be more convinient
+to specify the command as an array instead of a string:
+
+```toml
+[tool.pdm.scripts]
+start_server = {cmd = [
+	"flask",
+	"run",
+	# Important comment here about always using port 54321
+	"-p", "54321"
+]}
+```
+
 ### Shell script
 
 Shell scripts can be used to run more shell-specific tasks, such as pipeline and output redirecting.

--- a/news/cmd-scripts-array.md
+++ b/news/cmd-scripts-array.md
@@ -1,0 +1,1 @@
+Field `cmd` in `tools.pdm.scripts` configuration items now allows specifying an argument array instead of a string

--- a/pdm/cli/commands/run.py
+++ b/pdm/cli/commands/run.py
@@ -84,9 +84,9 @@ class Command(BaseCommand):
 
     def _normalize_script(self, script):
         if not getattr(script, "items", None):
-            # Must be a string, regard as the same as {cmd = "..."}
+            # Regard as the same as {cmd = ... }
             kind = "cmd"
-            value = str(script)
+            value = script
             options = {}
         else:
             script = dict(script)  # to remove the effect of tomlkit's container type.
@@ -117,7 +117,9 @@ class Command(BaseCommand):
         kind, value, options = self._normalize_script(script)
         options.pop("help", None)
         if kind == "cmd":
-            args = shlex.split(value) + list(args)
+            if not isinstance(value, list):
+                value = shlex.split(str(value))
+            args = value + list(args)
         elif kind == "shell":
             args = " ".join([value] + list(args))
             options["shell"] = True


### PR DESCRIPTION
## Pull Request Check List

- [X] A news fragment is added in `news/` describing what is new.
- [X] Test cases added for changed code.

## Describe what you have changed in this PR.

Field `cmd` in `tools.pdm.scripts` configuration items now allows specifying an argument array instead of a string.